### PR TITLE
fix: Display LiveTimeIndicator in foreground

### DIFF
--- a/lib/src/day_view/_internal_day_view_page.dart
+++ b/lib/src/day_view/_internal_day_view_page.dart
@@ -109,14 +109,6 @@ class InternalDayViewPage<T> extends StatelessWidget {
               showVerticalLine: showVerticalLine,
             ),
           ),
-          if (showLiveLine && liveTimeIndicatorSettings.height > 0)
-            LiveTimeIndicator(
-              liveTimeIndicatorSettings: liveTimeIndicatorSettings,
-              width: width,
-              height: height,
-              heightPerMinute: heightPerMinute,
-              timeLineWidth: timeLineWidth,
-            ),
           PressDetector(
             width: width,
             height: height,
@@ -148,6 +140,14 @@ class InternalDayViewPage<T> extends StatelessWidget {
             timeLineWidth: timeLineWidth,
             key: ValueKey(heightPerMinute),
           ),
+          if (showLiveLine && liveTimeIndicatorSettings.height > 0)
+            LiveTimeIndicator(
+              liveTimeIndicatorSettings: liveTimeIndicatorSettings,
+              width: width,
+              height: height,
+              heightPerMinute: heightPerMinute,
+              timeLineWidth: timeLineWidth,
+            ),
         ],
       ),
     );


### PR DESCRIPTION
LiveTimeIndicator was defined in a Stack, prior to Event tiles.
Thus it was displayed in background.
I moved the LiveTimeIndicator after the EventGenerator in the stack
children.

Before: LiveTimeIndicator hidden behind Event Tile

![before](https://user-images.githubusercontent.com/8408045/165476646-fe0445ba-04b8-40fb-84f2-19409a0a2709.png)

After: LiveTimeIndicator displayed in foreground

![after](https://user-images.githubusercontent.com/8408045/165476808-91f61716-6eae-423a-9709-4a24ab5381f1.png)

